### PR TITLE
Comment out fonts preventing terria from loading offline

### DIFF
--- a/lib/ReactViews/WelcomeMessage/welcome-message.scss
+++ b/lib/ReactViews/WelcomeMessage/welcome-message.scss
@@ -1,7 +1,7 @@
 @import "~terriajs-variables";
 @import "~terriajs-mixins";
-@import url("https://fonts.googleapis.com/css?family=Montserrat:700&display=swap");
-@import url("https://fonts.googleapis.com/css?family=Nunito:600,600i&display=swap");
+//@import url("https://fonts.googleapis.com/css?family=Montserrat:700&display=swap");
+//@import url("https://fonts.googleapis.com/css?family=Nunito:600,600i&display=swap");
 
 .WelcomeModalWrapper {
   color: $dark;


### PR DESCRIPTION
When observing network requests using firefox browser, two calls are made to google fonts service. These fail if we are in a disconnected environment (simulated during testing by blocking specific requests to these domains using firefox dev tools) the failure of these two fonts calls results in a white screen presented by Terria and it fails to load. Removing calls to these fonts results in successful loading during testing. Default behaviour when these fonts are removed is to fall back to fonts available to the browser - we have used this method elsewhere. These calls also relate to a welcome screen which isnt shown anyway. The real test will be to deploy this to the disconnected deployable laptops.